### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 ## DEMO
 ![MINE](./mine1.gif)
 
-#NOTE
+# NOTE
  Any pull request is available.
-#HOW TO USE
+# HOW TO USE
 ```java
 
        /**


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
