### PR TITLE
fix not remove GlobalLayoutListener

### DIFF
--- a/app/src/main/java/com/brucetoo/pinterestview/PinterestView.java
+++ b/app/src/main/java/com/brucetoo/pinterestview/PinterestView.java
@@ -348,6 +348,7 @@ public class PinterestView extends ViewGroup implements View.OnTouchListener {
         child.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
             @Override
             public void onGlobalLayout() {
+                child.getViewTreeObserver().removeOnGlobalLayoutListener(this);
                 Rect childRect = getChildDisPlayBounds(child);
                 if (mExpanded) {
                     expandAnimation(child, childRect);


### PR DESCRIPTION
If not, it will execute expand animation many times, and will leak